### PR TITLE
Fix byte compile warning

### DIFF
--- a/helm-pages.el
+++ b/helm-pages.el
@@ -84,7 +84,7 @@
 
 ;; The Helm datasource itself
 
-(defun helm-pages-name (&optional name)
+(defun helm-pages-name (&optional _name)
   "Get the name of the Helm pages source, for the user, where NAME is Helm's name."
   (with-helm-current-buffer
     (or


### PR DESCRIPTION
Variable which starts with underscore mean that they are unused.

I got following byte compile warning with original code.

```
helm-pages.el:87:1:Warning: Unused lexical argument `name'
```
