### PR TITLE
Add missing * to the helm buffer name

### DIFF
--- a/helm-pages.el
+++ b/helm-pages.el
@@ -119,7 +119,7 @@
   "View the pages in the current buffer with Helm."
   (interactive)
   (helm :sources '(helm-pages-source)
-        :buffer "*helm-pages"))
+        :buffer "*helm-pages*"))
 
 (provide 'helm-pages)
 ;;; helm-pages.el ends here


### PR DESCRIPTION
All system buffers, including helm buffers, have asterisks at their name's start and end. An asterisk is missing at the end of `*helm-pages`.
