### PR TITLE
Add compatibility shim for 24.x

### DIFF
--- a/helm-pages.el
+++ b/helm-pages.el
@@ -108,6 +108,11 @@ page number."
         (goto-char (helm-pages--page-start page-number))
         (helm-pages-get-next-header)))))
 
+; Compatibility Shim
+(unless (fboundp 'font-lock-ensure)
+  (defun font-lock-ensure ()
+    (font-lock-fontify-buffer)))
+
 (defun helm-pages-get-pages ()
   "Return a list of (POS . HEADER) pairs.
 


### PR DESCRIPTION
I don't know if you're interested in supporting it at this point, but `font-lock-ensure` isn't in 24.x.
This emulates it by just falling back to `font-lock-fontify-buffer`. I'm not sure if it's the absolutely correct solution, but it doesn't crash and everything looks correct.